### PR TITLE
Update ze_platformer_b2.cfg

### DIFF
--- a/mapcfg/ze_platformer_b2.cfg
+++ b/mapcfg/ze_platformer_b2.cfg
@@ -7,4 +7,6 @@ zr_ztele_zombie "0"
 // Default: "1"
 zr_ztele_human_before "0"
 
+sm_nofalldamage 1
+
 hook_boss_enable 0


### PR DESCRIPTION
地图自带免摔有点问题，有时候开局还是会摔死。