### PR TITLE
Update ze_lotr_minas_tirith_p5.cfg

### DIFF
--- a/mappool/ze_lotr_minas_tirith_p5.cfg
+++ b/mappool/ze_lotr_minas_tirith_p5.cfg
@@ -2,7 +2,9 @@
 {
 	"ze_lotr_minas_tirith_p5"
 	{
-    "onlynominate" "1"
-    "onlyadmin" "1"
+	"chi"		"魔戒3:米那斯提力斯"
+	"credit"		"2000"
+	"CanNominateInterval"		"432000"
+	"AllowNominateTime" "18|19|20|21"
 	}
 }


### PR DESCRIPTION
P5版本的米纳斯已经不炸服了，经过一段时间的stripper修复测试，也可以正常玩，但是因为地图难度原因，所以设定了地图的CD时长和限制了预定时间，提高了定图所需积分