### PR TITLE
Update ze_slender_escape_rc2.cfg

### DIFF
--- a/mapcfg/ze_slender_escape_rc2.cfg
+++ b/mapcfg/ze_slender_escape_rc2.cfg
@@ -1,3 +1,4 @@
+mp_timelimit 45
 zr_ztele_max_zombie 0
 zr_ztele_max_human 0
 zr_ztele_zombie 0


### PR DESCRIPTION
4关+多个小游戏关卡，然后现在禁雷达和传送第三关一般都卡不少次~
因此初始时间加些。