### PR TITLE
Update ze_onahole_v3.cfg

### DIFF
--- a/mappool/ze_onahole_v3.cfg
+++ b/mappool/ze_onahole_v3.cfg
@@ -3,6 +3,6 @@
 	"ze_onahole_v2_2_2_2_2"
 	{
 		"CanNominateInterval"		"532000"
-		"AllowNominateTime" "1|2|3|4|5"
+		"AllowNominateTime" "00|01|02|03|04|05"
 	}
 }


### PR DESCRIPTION
服务器系统时间为01、02、03、04、05。参数里必须完全匹配才行，因此参数里也改成相对应的。此外，多加个00，1点后太晚了~