### PR TITLE
Update ze_frostdrake_tower_v1.cfg

### DIFF
--- a/mapcfg/ze_frostdrake_tower_v1.cfg
+++ b/mapcfg/ze_frostdrake_tower_v1.cfg
@@ -19,3 +19,5 @@ sm_devzone_enable_give_use_timer "1"
 sm_devzone_enable_give_money "1150"
 sm_g_cv_Money "14500"
 hook_boss_enable "1"
+
+zr_poison_enabled 0


### PR DESCRIPTION
现在冰龙没有加血雷。最后见龙前的第二个长时间守点（一般守箱子），僵尸算好传送时间前放毒能够拖住或者毒死很多人。尸笼开的很快。。。前面路上也有一个点（虽然那里没多大用）。