### PR TITLE
Update ze_PKMN_Adventure_v9c.cfg

### DIFF
--- a/mapcfg/ze_PKMN_Adventure_v9c.cfg
+++ b/mapcfg/ze_PKMN_Adventure_v9c.cfg
@@ -9,3 +9,4 @@ sm_nofalldamage 1
 sm_g_cv_money 10000
 zr_class_modify "zombies" "knockback" 5
 zr_infect_mzombie_ratio "7"
+zr_poison_enabled "0"


### PR DESCRIPTION
第五关最后的跳刀要贴着平台最后面躲旋转刀，尸笼就在平台背后，会隔空气墙放毒，禁掉