### PR TITLE
Create ze_FFXII_Paramina_Rift_r4.cfg

### DIFF
--- a/mappool/ze_FFXII_Paramina_Rift_r4.cfg
+++ b/mappool/ze_FFXII_Paramina_Rift_r4.cfg
@@ -1,0 +1,10 @@
+"mapname"
+{
+	  "ze_FFXII_Paramina_Rift_r4"
+	{
+	  "chi"		"最终幻想12：帕拉米亚"
+    "credit"		"300"
+    "onlynominate" "1"
+    "onlyadmin" "1" 
+	}
+}


### PR DESCRIPTION
r4版本有神器等级BUG（无法叠神器等级，部分玩家始终为1级），现在服务器有相对稳定的r3版本，没有什么大影响问题。