### PR TITLE
Update ze_FFVII_Cosmo_Canyon_v5k_fix.cfg

### DIFF
--- a/stripper/ze_FFVII_Cosmo_Canyon_v5k_fix.cfg
+++ b/stripper/ze_FFVII_Cosmo_Canyon_v5k_fix.cfg
@@ -131,8 +131,8 @@ modify:
 		  "OnNewGame" "cmdCommandzr_class_modify humans health_regen_amount 001"
 		  "OnNewGame" "cmdCommandzr_class_modify zombies health_regen_interval 0.001"
 		  "OnNewGame" "cmdCommandzr_class_modify zombies health_regen_amount 001"
-		  "OnNewGame" "cmdCommandzr_class_modify zombies health_regen_amount 001"
-		  "OnNewGame" "consolaCommandsm_zeusweapons_decoy 001"
-		  "OnNewGame" "consolaCommandsm_zeusweapons_smoke 101"
+		  "OnNewGame" "cmdCommandsm_cvar sm_zeusweapons_decoy 001"
+		  "OnNewGame" "cmdCommandsm_cvar sm_smoke_limit 001"
+		  "OnNewGame" "cmdCommandsm_cvar sm_zeusweapons_hegrenade 201"
 	  }
 }


### PR DESCRIPTION
去掉初始冰和购买冰。因为初始只有6000，增加一颗初始高爆。