### PR TITLE
Update ze_FFXII_Paramina_Rift_v1_4_a7t.cfg

### DIFF
--- a/mapcfg/ze_FFXII_Paramina_Rift_v1_4_a7t.cfg
+++ b/mapcfg/ze_FFXII_Paramina_Rift_v1_4_a7t.cfg
@@ -15,6 +15,5 @@ hook_boss_money_min "20"
 zr_infect_spawntime_min "10.0"
 zr_infect_spawntime_max "10.0"
 zr_ztele_max_human "0"
-zr_infect_mzombie_ratio "6.5"
 
 sm_flashlight_enabled 0	//禁用手电筒防止打皇帝时意外开启手电筒导致客户端闪退

--- a/mapcfg/ze_FFXII_Paramina_Rift_v1_4_a7t.cfg
+++ b/mapcfg/ze_FFXII_Paramina_Rift_v1_4_a7t.cfg
@@ -1,17 +1,20 @@
-mp_timelimit 40
+mp_timelimit 60
 
 sm_g_cv_Money "12000"
-sm_he_limit "10"
+sm_he_limit "8"
 sm_molotov_limit "2"
 sm_decoy_limit "0"
 sm_smoke_limit "1"
 sm_flash_limit "0"
 sm_taggrenade_limit "0"
+sm_snowball_price "0"
+zr_grenlauncher_enable 0
 
 hook_boss_money_max "40"
 hook_boss_money_min "20"
 zr_infect_spawntime_min "10.0"
 zr_infect_spawntime_max "10.0"
 zr_ztele_max_human "0"
-sm_snowball_price "0"
-zr_grenlauncher_enable 0
+zr_infect_mzombie_ratio "6.5"
+
+sm_flashlight_enabled 0	//禁用手电筒防止打皇帝时意外开启手电筒导致客户端闪退


### PR DESCRIPTION
禁用手电筒,防止打皇帝时意外开启手电筒导致客户端闪退
地图难度大,增加点基础时间,略微提高点尸变比