### PR TITLE
Update ze_rush_B_v1_4.cfg

### DIFF
--- a/mapcfg/ze_rush_B_v1_4.cfg
+++ b/mapcfg/ze_rush_B_v1_4.cfg
@@ -3,7 +3,8 @@ mp_roundtime 20
 zr_class_modify "zombies" "knockback" 5
 zr_infect_mzombie_ratio "6"
 sm_he_limit "4" 
-sm_smoke_limit "2" 
-sm_molotov_limit "2"
+sm_smoke_limit "3" 
+sm_molotov_limit "3"
 zr_poison_enabled "0"
 sm_decoy_limit "1"
+sm_taggrenade_limit "0"


### PR DESCRIPTION
泡泡雷会导致僵尸强制击飞无法正常获取神器，故删除，同时该图基本不需要任何泡泡雷的防守点，均可以通过火瓶及冰弥补