### PR TITLE
修复拾取神器后错误传送到其他神器位置

### DIFF
--- a/stripper/ze_rizomata_b44.cfg
+++ b/stripper/ze_rizomata_b44.cfg
@@ -708,5 +708,17 @@ modify:
     }	
 }
 
+//fix teleporter error//
+modify:
+{
+    match:
+    {
+        "classname" "weapon_knife"
+    }
+	insert:
+    {
+        "OnPlayerPickup" "!activatorRunScriptCodeactivator.SetVelocity(Vector(0,0,0));01"
+    }	
+}
 #PUSH
 


### PR DESCRIPTION
神器房挡板被移除，惯性可能导致玩家拾取神器后移动到另一个神器的传送点