### PR TITLE
删除过期拾取神器触发的PUSH，修复诅咒死亡后仍可使用的问题

### DIFF
--- a/stripper/ze_rizomata_b45.cfg
+++ b/stripper/ze_rizomata_b45.cfg
@@ -734,16 +734,33 @@ modify:
     }	
 }
 
-//fix teleporter error//
+//fix curse can use after dead//
 modify:
 {
     match:
     {
-        "classname" "weapon_knife"
+        "classname" "game_ui"
+        "targetname" "curse_ui"
     }
 	insert:
     {
-        "OnPlayerPickup" "!activatoraddoutputbasevelocity 0 0 -1000;01"
+        "PressedAttack2" "curse_particleFireUser10-1"
+    }	
+    delete:
+    {
+	"PressedAttack2" "curse_compareCompare0-1"
+    }
+}
+modify:
+{
+    match:
+    {
+        "classname" "info_particle_system"
+        "targetname" "curse_particle"
+    }
+	insert:
+    {
+        "OnUser1" "curse_compareCompare0-1"
     }	
 }
 #PUSH


### PR DESCRIPTION
精灵塔新版本已添加空气墙，拾取神器不会错误传送