### PR TITLE
尸变时间过短，导致僵尸出生在人群中。

### DIFF
--- a/mapcfg/ze_colors_p3.cfg
+++ b/mapcfg/ze_colors_p3.cfg
@@ -1,0 +1,2 @@
+zr_infect_spawntime_min 20
+zr_infect_spawntime_max 20


### PR DESCRIPTION
尸变时间过短，导致僵尸出生在人群中。