### PR TITLE
开荒配置修改

### DIFF
--- a/mapcfg/ze_japans_3rd_bombing_v3.cfg
+++ b/mapcfg/ze_japans_3rd_bombing_v3.cfg
@@ -1,5 +1,10 @@
+mp_timelimit 45
 sm_nofalldamage 1
 sm_he_limit 7
 sm_smoke_limit 2
-sm_molotov_limit 2
+sm_molotov_limit 5
 sm_g_cv_money 9000
+sm_spawn_give_armor 1
+zr_infect_spawntime_min 25
+zr_infect_spawntime_max 25
+zr_ztele_zombie 0


### PR DESCRIPTION
地图三关，每关十五分钟左右。守点压力大，加点火瓶。第三关非常吃护甲 ex关有npc，吃护甲。建议赠送护甲。禁用传送指令，用指令会被传回出生点或者是原地tp。地图作者设定。这张图没有会卡人的地方。增加尸变时间是因为开局有人类传送到僵尸屋子的bug，被传送到僵尸房的人类在尸变前切观察可以解决问题，加点时间给人类反应，改动不会破坏地图流程。这个问题作者说不是地图bug，是服务器的原因。