### PR TITLE
预定积分调整

### DIFF
--- a/mappool/ze_ffxii_westersand_v7_z9.cfg
+++ b/mappool/ze_ffxii_westersand_v7_z9.cfg
@@ -4,7 +4,7 @@
 	{
 		"chi"		"最终幻想12：西沙v7"
 		"CanNominateInterval"		"345600"
-		"credit"	"2400"
+		"credit"	"3000"
 		"onlynominate"		"1"
 	}
 }


### PR DESCRIPTION
根据数据检测，地图游玩次数太高，调高预定积分以提高订图成本，多玩其他地图