### PR TITLE
防止僵尸碰小孩重复死亡，火箭只能由人类触发

### DIFF
--- a/stripper/ze_best_korea_v1.cfg
+++ b/stripper/ze_best_korea_v1.cfg
@@ -383,5 +383,30 @@ add:
 	"disablereceiveshadows" "1"
 	"classname" "func_brush"
 }
-//
-#PUSH
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"origin" "7583 8706.01 7226.9"
+	}
+	insert:
+	{
+		"filtername" "filter_ct"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"origin" "7680 14272 9540"
+	}
+	insert:
+	{
+		"filtername" "filter_ct"
+	}
+}
+


### PR DESCRIPTION
防止僵尸碰小孩重复死亡，火箭只能由人类触发