### PR TITLE
移除僵尸毒

### DIFF
--- a/mapcfg/ze_titanic_realism_escapex.cfg
+++ b/mapcfg/ze_titanic_realism_escapex.cfg
@@ -1,0 +1,1 @@
+zr_poison_enabled "0"


### PR DESCRIPTION
新图开荒难度较大，该地图守电梯阶段人类极易被僵尸毒团灭，请求暂时移除僵尸毒，通关后再做决定。