### PR TITLE
禁用EX模式开局人类神器，暂时删除连关机制

### DIFF
--- a/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
+++ b/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
@@ -593,7 +593,7 @@ function SetShopCheat()
 
 function CheckAutoSlay(stageind)
 {
-	if(firststage){firststage=false;}else if(!extreme)
+	if(firststage){firststage=false;}else if(!extreme || extreme)
 	{
 		local ctc_check = 0;
 		local tc_check = 0;
@@ -989,7 +989,7 @@ function ResetMap(button=false)
 
 function ExtremeCheck()
 {
-	if (extreme)
+	if (extreme && !extreme)
 	{
 		ResetMapBase();
 	}
@@ -1734,13 +1734,13 @@ function SpawnExtremeZombieItem(stage)	//TODO - spawn in zombie items based on t
 		//red heal:			ITEMX_tem_hich_heal
 		//yellow heal:		ITEMX_tem_hich_legendaryheal
 		//--------------------------------
-		ExevSpawn("ITEMX_tem_hich_heal",humanitem_pos+Vector(-64,96,4));
-		ExevSpawn("ITEMX_tem_qaz_small",humanitem_pos+Vector(-64,32,4));
-		ExevSpawn("ITEMX_tem_qaz_small",humanitem_pos+Vector(-64,-32,4));
-		ExevSpawn("ITEMX_tem_qaz_mid",humanitem_pos+Vector(-64,-96,4));
-		ExevSpawn("ITEMX_tem_ord_dick",humanitem_pos+Vector(64,96,4));
-		ExevSpawn("ITEMX_tem_Turtle_push",humanitem_pos+Vector(64,32,4));
-		ExevSpawn("ITEMX_tem_luffaren_diddlecannon",humanitem_pos+Vector(64,-32,4));
+		//ExevSpawn("ITEMX_tem_hich_heal",humanitem_pos+Vector(-64,96,4));
+		//ExevSpawn("ITEMX_tem_qaz_small",humanitem_pos+Vector(-64,32,4));
+		//ExevSpawn("ITEMX_tem_qaz_small",humanitem_pos+Vector(-64,-32,4));
+		//ExevSpawn("ITEMX_tem_qaz_mid",humanitem_pos+Vector(-64,-96,4));
+		//ExevSpawn("ITEMX_tem_ord_dick",humanitem_pos+Vector(64,96,4));
+		//ExevSpawn("ITEMX_tem_Turtle_push",humanitem_pos+Vector(64,32,4));
+		//ExevSpawn("ITEMX_tem_luffaren_diddlecannon",humanitem_pos+Vector(64,-32,4));
 		//ExevSpawn("XXXXXXXXXXXXXXX",humanitem_pos+Vector(64,-96,4));
 		//ExevSpawn("XXXXXXXXXXXXXXX",humanitem_pos+Vector(0,96,4));
 		//ExevSpawn("XXXXXXXXXXXXXXX",humanitem_pos+Vector(0,32,4));


### PR DESCRIPTION
#4版本的更新下降了EX模式的各关卡难度，并且额外增加了开局人类神器，但通关预期依旧不太理想，整体难度变化不明显。连关打基本上只能打一至两个小游戏，还是继续删除连关机制打打看，等作者再次更新版本后恢复连关机制。不连关情况下每个小游戏都会出现人类神器，故禁用。