### PR TITLE
删除天堂塔楼禁止圣战点位

### DIFF
--- a/stripper/ze_diddle_v3.cfg
+++ b/stripper/ze_diddle_v3.cfg
@@ -495,51 +495,6 @@ add:
 	"angles" "0 0 0"
 	"effect_name" "custom_particle_010"
 	"targetname" "NO_JIHAD"
-	"origin" "-15080 -9592 2904"
-}
-
-add:
-{
-	"classname" "info_particle_system"
-	"angles" "0 0 0"
-	"effect_name" "custom_particle_010"
-	"targetname" "NO_JIHAD"
-	"origin" "-15080 -9592 2648"
-}
-
-add:
-{
-	"classname" "info_particle_system"
-	"angles" "0 0 0"
-	"effect_name" "custom_particle_010"
-	"targetname" "NO_JIHAD"
-	"origin" "-15080 -9592 2200"
-}
-
-add:
-{
-	"classname" "info_particle_system"
-	"angles" "0 0 0"
-	"effect_name" "custom_particle_010"
-	"targetname" "NO_JIHAD"
-	"origin" "-14612.3 -10485.3 2696"
-}
-
-add:
-{
-	"classname" "info_particle_system"
-	"angles" "0 0 0"
-	"effect_name" "custom_particle_010"
-	"targetname" "NO_JIHAD"
-	"origin" "-14612.3 -10069.3 2696"
-}
-
-add:
-{
-	"classname" "info_particle_system"
-	"angles" "0 0 0"
-	"effect_name" "custom_particle_010"
-	"targetname" "NO_JIHAD"
 	"origin" "1226.25 -8435.96 1272"
 }
 


### PR DESCRIPTION
现圣战已经无法利用丢刀设定引爆，故删除。