### PR TITLE
增加可购买手雷

### DIFF
--- a/mapcfg/ze_FFVII_Mako_Reactor_v5_3_v5.cfg
+++ b/mapcfg/ze_FFVII_Mako_Reactor_v5_3_v5.cfg
@@ -66,7 +66,7 @@ sm_flash_push "0"
 // Limit HE
 // -
 // Default: "1"
-sm_he_limit "2"
+sm_he_limit "3"
 
 // Limit molotov
 // -


### PR DESCRIPTION
根据调查，正常断后并且可过关本图玩家里有超过2/3反应后面手雷数量不足，增加一个处理