### PR TITLE
地图难度回调

### DIFF
--- a/stripper/ze_ffxii_westersand_v8zeta1_x18.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1_x18.cfg
@@ -15,7 +15,7 @@ modify:
 	}
 	insert:
 	{
-		"OnUser1" "!selfSetHealth45001"
+		"OnUser1" "!selfSetHealth37501"
 	}
 }
 
@@ -32,7 +32,7 @@ modify:
 	}
 	insert:
 	{
-		"OnUser1" "!selfSetHealth45001"
+		"OnUser1" "!selfSetHealth37501"
 	}
 }
 
@@ -49,7 +49,7 @@ modify:
 	}
 	insert:
 	{
-		"OnUser1" "!selfSetHealth55001"
+		"OnUser1" "!selfSetHealth45001"
 	}
 }
 
@@ -69,7 +69,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "Boss_Health_InitAdd380-1"
+		"OnStartTouch" "Boss_Health_InitAdd400-1"
 	}
 }
 
@@ -86,24 +86,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "Boss_Health_InitAdd280-1"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"targetname" "Chaos_Hp_To_Boss"
-		"classname" "trigger_once"
-	}
-	delete:
-	{
-		"OnStartTouch" "Boss_Health_InitAdd200-1"
-	}
-	insert:
-	{
-		"OnStartTouch" "Boss_Health_InitAdd170-1"
+		"OnStartTouch" "Boss_Health_InitAdd300-1"
 	}
 }
 


### PR DESCRIPTION
因前期玩家水平不一，地图难度被人工下调，现做出回调
1.提高了地图BOSS血量，轮回王血量设为地图默认值
2.削弱管道血量