### PR TITLE
添加地图译名

### DIFF
--- a/mappool/ze_surf_shonyudo_v1.cfg
+++ b/mappool/ze_surf_shonyudo_v1.cfg
@@ -1,0 +1,7 @@
+"mapname"
+{
+	"ze_surf_shonyudo_v1"
+	{
+		"chi"		"山涧幽谷滑翔旧版"
+	}
+}


### PR DESCRIPTION
补充说明：我重新部署了该地图的老版本，旧版是老玩家都喜欢的咸鱼版本。由于新旧版难度差距特别大，新版属于长征滑翔难图，正常玩很少人愿意带这张图，除非有活动，我想让x社服务器同时存在两个地图版本供玩家自由选择。希望能审核通过