### PR TITLE
修复给予玩家属性的命令不起作用

### DIFF
--- a/stripper/ze_pizzatime_v9.cfg
+++ b/stripper/ze_pizzatime_v9.cfg
@@ -12,7 +12,7 @@ modify:
 }
 
 
-;Case01为简单模式，Case02为正常模式
+;Case01为原版(normal)，Case02为枫哥版本(easy)
 add:
 {
 	"targetname" "mode_case"
@@ -27,7 +27,7 @@ add:
 	"OnCase02" "serverCommandsay ***Easy Mode***31"
 	"OnCase02" "serverCommandsay ***Easy Mode***3.21"
 	"OnCase02" "serverCommandsay ***Easy Mode***3.41"
-	"OnCase02" "!playerAddOutputtargetname father01"
+	"OnCase02" "pizzaplayerAddOutputtargetname father01"
 }
 
 
@@ -88,7 +88,7 @@ add:
 	"Negated" "0"
 	"origin" "10638 -13631.7 76"
 	"OnPass" "mode_counterSetValue201"
-	"OnPass" "!playerAddOutputtargetname father01"
+	"OnPass" "pizzaplayerAddOutputtargetname father01"
 	"OnPass" "grill_buttonUnlock31"
 	"OnPass" "serverCommandsay ***Easy Mode Enabled***01"
 }
@@ -129,7 +129,7 @@ add:
 	"filterteam" "3"
 	"Negated" "0"
 	"origin" "10650 -13697.8 78"
-	"OnPass" "!playerAddOutputtargetname pizzaplayer01"
+	"OnPass" "fatherAddOutputtargetname pizzaplayer01"
 	"OnPass" "grill_buttonLock31"
 	"OnPass" "mode_counterSetValue101"
 	"OnPass" "serverCommandsay ***Normal Mode Enabled***01"

--- a/stripper/ze_pizzatime_v9.cfg
+++ b/stripper/ze_pizzatime_v9.cfg
@@ -27,7 +27,7 @@ add:
 	"OnCase02" "serverCommandsay ***Easy Mode***31"
 	"OnCase02" "serverCommandsay ***Easy Mode***3.21"
 	"OnCase02" "serverCommandsay ***Easy Mode***3.41"
-	"OnCase02" "pizzaplayerAddOutputtargetname father01"
+	"OnCase02" "playerAddOutputtargetname father01"
 }
 
 
@@ -88,7 +88,7 @@ add:
 	"Negated" "0"
 	"origin" "10638 -13631.7 76"
 	"OnPass" "mode_counterSetValue201"
-	"OnPass" "pizzaplayerAddOutputtargetname father01"
+	"OnPass" "playerAddOutputtargetname father01"
 	"OnPass" "grill_buttonUnlock31"
 	"OnPass" "serverCommandsay ***Easy Mode Enabled***01"
 }
@@ -129,7 +129,7 @@ add:
 	"filterteam" "3"
 	"Negated" "0"
 	"origin" "10650 -13697.8 78"
-	"OnPass" "fatherAddOutputtargetname pizzaplayer01"
+	"OnPass" "playerAddOutputtargetname pizzaplayer01"
 	"OnPass" "grill_buttonLock31"
 	"OnPass" "mode_counterSetValue101"
 	"OnPass" "serverCommandsay ***Normal Mode Enabled***01"


### PR DESCRIPTION
!player不能在服务器里指代玩家，改用pizzaplayer。pizzaplayer是该地图为没有密道属性和真神器属性的玩家给予的targetname。