### PR TITLE
ex模式给予高击退

### DIFF
--- a/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
+++ b/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
@@ -500,14 +500,12 @@ function RoundStart()
 	{
 		coins_max = coins_max_extrememode;
 		EntFire("manager", "RunScriptCode", "VoteMsg();", 4.00, null);
-		EntFire("server", "Command", "sm_he_limit 20", 0.00, null);
+		EntFire("server", "Command", "sm_he_limit 15", 0.00, null);
 		EntFire("server", "Command", "sm_smoke_limit 3", 0.00, null);
 		EntFire("server", "Command", "sm_rcon sm_molotov_limit 5", 0.00, null);
-		EntFire("server", "Command", "sm_rcon sm_taggrenade_limit 2", 0.00, null);
 		EntFire("server", "Command", "sm_rcon zr_infect_mzombie_ratio 7", 0.00, null);
 		EntFire("server", "Command", "sm_rcon sm_mine_limit 2", 0.00, null);
-		EntFire("server", "Command", "sm_rcon hook_boss_money_min 15", 0.00, null);
-		EntFire("server", "Command", "sm_rcon hook_boss_money_max 15", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.knockback.multiplier 7.0", 0.00, null);
 		exmvote_voteallowed = true;
 		EntFireByHandle(self, "RunScriptCode", " exmvote_voteallowed = false; ", 10.90, null, null);
 		ExevRoundStart();

--- a/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
+++ b/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
@@ -505,7 +505,9 @@ function RoundStart()
 		EntFire("server", "Command", "sm_rcon sm_molotov_limit 5", 0.00, null);
 		EntFire("server", "Command", "sm_rcon zr_infect_mzombie_ratio 7", 0.00, null);
 		EntFire("server", "Command", "sm_rcon sm_mine_limit 2", 0.00, null);
-		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.knockback.multiplier 7.0", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.knockback.multiplier 5.5", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.knockback.airmultiplier 0.5", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.money.rewardratio 0.8", 0.00, null);
 		exmvote_voteallowed = true;
 		EntFireByHandle(self, "RunScriptCode", " exmvote_voteallowed = false; ", 10.90, null, null);
 		ExevRoundStart();
@@ -520,6 +522,9 @@ function RoundStart()
 		EntFire("server", "Command", "sm_rcon sm_molotov_limit 2", 0.00, null);
 		EntFire("server", "Command", "sm_rcon zr_infect_mzombie_ratio 6", 0.00, null);
 		EntFire("server", "Command", "sm_rcon sm_mine_limit 1", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.knockback.multiplier 4.5", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.knockback.airmultiplier 0.15", 0.00, null);
+		EntFire("server", "Command", "sm_rcon sm_xsys_config change xsys.money.rewardratio 0.65", 0.00, null);
 	}
 	humanitems_firstround = true;
 	stageChosen = -1;


### PR DESCRIPTION
ex模式难度也都知道，新stp削弱了墙神器，加上93x关闭呼吸回血，难度变高，ex路途中有大量NPC和陷阱，伤害高 还有随机性,加点击退弥补人类人数上的劣势（不至于原先参数快1比1人数就压不住了）

地图难度整太高带都没人愿意带。更别说通关(现在火力没以前厉害，炸多了直接摆烂 没意义)