### PR TITLE
删除final关开局商店密道

### DIFF
--- a/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
+++ b/scripts/vscripts/luffaren/_mapscripts/ze_diddle/manager_patched.nut
@@ -555,13 +555,13 @@ function RoundStart()
 			local shopcheatrng = RandomInt(0,100);
 			if(shopcheatrng > 50)
 			{
-				EntFire("stripstrop_shopcheat","AddOutput","origin 4488 880 600",0.00,null);
+				EntFire("stripstrop_diddlefriend","AddOutput","origin 4488 880 600",0.00,null);
 				EntFire("stripstrop_diddlefriend","AddOutput","origin 4488 1168 600",0.00,null);
 			}
 			else
 			{
 				EntFire("stripstrop_diddlefriend","AddOutput","origin 4488 880 600",0.00,null);
-				EntFire("stripstrop_shopcheat","AddOutput","origin 4488 1168 600",0.00,null);
+				EntFire("stripstrop_diddlefriend","AddOutput","origin 4488 1168 600",0.00,null);
 			}
 			specdevils.clear();
 			shopangels.clear();


### PR DESCRIPTION
删除final关开局商店密道，现在两边都替换为小黑屋。避免开局有人通过赌密道而尸变，除5个地图作者外无其他shopcheat方式